### PR TITLE
Update the SingleBarChart example

### DIFF
--- a/docs/charts.rst
+++ b/docs/charts.rst
@@ -116,7 +116,7 @@ This widget will render a bar chart of top three players:
 
 .. code-block:: python
 
-    class MySingleBarChart(widgets.SimpleBarChart):
+    class MySingleBarChart(widgets.SingleBarChart):
         # label and series
         values_list = ('username', 'score')
         # Data source


### PR DESCRIPTION
This fixes the parent class for the example MySingleBarChart class. The MySingleBarChart class was inheriting from SimpleBarChart instead of SingleBarChart.