### PR TITLE
Updates dashboard.html to extend admin/base_site.html

### DIFF
--- a/controlcenter/templates/controlcenter/dashboard.html
+++ b/controlcenter/templates/controlcenter/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "admin/base.html" %}
+{% extends "admin/base_site.html" %}
 {% load cache controlcenter_tags %}
 
 {% block title %}{{ dashboard.title }}{% endblock %}


### PR DESCRIPTION
If you extend admin/base_site.html instead of just admin/base.html you get all of the customizations that are done in a standard way when customizing the admin. I've done this in a project and it seems to work great.
