### PR TITLE
Support for slug url format for dashboards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,14 @@ Update settings file:
         'project.dashboards.MyDashboard',
     )
 
+The ``CONTROLCENTER_DASHBOARDS`` setting may also be a dictionary with the keys being the desired url slugs.
+
+.. code-block:: python
+
+    CONTROLCENTER_DASHBOARDS = {
+        'widgets': 'project.dashboards.WidgetDashboard',
+    }
+
 Plug in urls:
 
 .. code-block:: python
@@ -68,7 +76,7 @@ Plug in urls:
         ...
     ]
 
-Open ``/admin/dashboard/0/`` in browser.
+Open ``/admin/dashboard/0/`` in browser. (``/admin/dashboard/widgets/`` if you went with slugs)
 
 
 Documentation

--- a/controlcenter/views.py
+++ b/controlcenter/views.py
@@ -15,18 +15,23 @@ class ControlCenter(object):
         self.view_class = view_class
 
     def get_dashboards(self):
-        _dashboards = app_settings.DASHBOARDS
-        if isinstance(_dashboards, dict):
-            dashboards = {
-                slug: import_string(klass)(pk=slug)
-                for slug, klass in _dashboards.items()
-            }
+        if isinstance(app_settings.DASHBOARDS, dict):
+            dashboards = self.slug_dashboards()
         else:
-            klasses = map(import_string, app_settings.DASHBOARDS)
-            dashboards = [klass(pk=pk) for pk, klass in enumerate(klasses)]
+            dashboards = self.pk_dashboards()
         if not dashboards:
             raise ImproperlyConfigured('No dashboards found.')
         return dashboards
+
+    def pk_dashboards(self):
+        klasses = map(import_string, app_settings.DASHBOARDS)
+        return [klass(pk=pk) for pk, klass in enumerate(klasses)]
+
+    def slug_dashboards(self):
+        return {
+            slug: import_string(klass)(pk=slug)
+            for slug, klass in app_settings.DASHBOARDS.items()
+        }
 
     def get_view(self):
         dashboards = self.get_dashboards()

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -22,6 +22,11 @@ class AppConfTest(TestCase):
         self.assertEqual(app_settings.DASHBOARDS, [Dashboard])
         self.assertEqual(app_settings.CHARTIST_COLORS, 'google')
 
+    @override_settings(
+        CONTROLCENTER_DASHBOARDS={'default': Dashboard})
+    def test_changes_with_slug(self):
+        self.assertEqual(app_settings.DASHBOARDS, {'default': Dashboard})
+
     def test_unknown(self):
         with self.assertRaises(AttributeError):
             app_settings.DEBUG

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -87,6 +87,21 @@ class B_DashboardTest(TestCase):
         self.assertIsInstance(next(dashboard.get_widgets(request=None)),
                               widgets.Group)
 
+    @override_settings(
+        ROOT_URLCONF='test_urls',
+        CONTROLCENTER_DASHBOARDS={'empty': 'dashboards.EmptyDashboard',
+                                  'non-empty': 'dashboards.NonEmptyDashboard'})
+    def test_slug_dashboard(self):
+        url = reverse('controlcenter:dashboard-slug', kwargs={'slug': 'non-empty'})
+        # Staff proceed
+        from django.conf import settings
+        print(settings.CONTROLCENTER_DASHBOARDS)
+        import controlcenter
+        print(controlcenter.app_settings.DASHBOARDS)
+        self.client.login(username='superuser', password='superpassword')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_multiple_dashboards(self):
         self.client.login(username='superuser', password='superpassword')
         dashboards = ['dashboards.NonEmptyDashboard' for i in range(30)]


### PR DESCRIPTION
I wasn't really 100% pleased with a url structure like `/admin/dashboard/0/`, as they don't really say much about what the page may contain.

This pull request allows you to create more descriptive urls like this: `/admin/dashboard/widgets/` by allowing `CONTROLCENTER_DASHBOARDS` to be a dictionary like so

```python
CONTROLCENTER_DASHBOARDS = {
    'widgets': 'project.dashboards.WidgetDashboard',
}
```