### PR TITLE
Fix tests for Django 2.1

### DIFF
--- a/test_project/dashboards.py
+++ b/test_project/dashboards.py
@@ -6,11 +6,11 @@ class EmptyDashboard(Dashboard):
 
 
 class MyWidget0(widgets.Widget):
-    pass
+    template_name = 'chart.html'
 
 
 class MyWidget1(widgets.Widget):
-    pass
+    template_name = 'chart.html'
 
 
 class NonEmptyDashboard(Dashboard):


### PR DESCRIPTION
This avoids an _"AssertionError: MyWidget0.template_name is not defined."_ on Django 2.1, which no longer silences `{% include %}` exceptions.

Django deprecation notes:

https://docs.djangoproject.com/en/2.1/internals/deprecation/#deprecation-removed-in-2-1