### PR TITLE
Dashboard CSS: Fix include order so that colors override correctly

### DIFF
--- a/controlcenter/dashboards.py
+++ b/controlcenter/dashboards.py
@@ -21,9 +21,10 @@ class Dashboard(six.with_metaclass(MediaDefiningClass, BaseModel)):
     class Media:
         css = {
             'all': [
+                'controlcenter/css/chartist.css',
+                # This must follow chartist.css to override correctly:
                 ('controlcenter/css/chartist-{}-colors.css'
                  .format(app_settings.CHARTIST_COLORS)),
-                'controlcenter/css/chartist.css',
                 'controlcenter/css/all.css',
             ]
         }


### PR DESCRIPTION
Without this, the styles in `chartist.css` still end up overriding some of the styles in `chartist-material-colors.css`, when using `CONTROLCENTER_CHARTIST_COLORS = 'material'`.