### PR TITLE
Updated long_description argument in setup.py from README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from io import open
 from os import path
 
 from setuptools import find_packages, setup

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
+from os import path
+
 from setuptools import find_packages, setup
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name='django-controlcenter',
     version='0.2.7',
     description='Set of widgets to build dashboards for your Django-project.',
-    long_description='',
+    long_description=long_description,
     url='https://github.com/byashimov/django-controlcenter',
     author='Murad Byashimov',
     author_email='byashimov@gmail.com',


### PR DESCRIPTION
I've created this PR to show the README and useful links in the PyPi packages page, removing the message "The author of this package has not provided a project description":
https://pypi.org/project/django-controlcenter/