### PR TITLE
syntax error in template

### DIFF
--- a/controlcenter/templates/controlcenter/widgets/contrib/key_value_list.html
+++ b/controlcenter/templates/controlcenter/widgets/contrib/key_value_list.html
@@ -1,6 +1,6 @@
 {% load controlcenter_tags %}
 
-<table class="controlcenter__table" {% if widget.sortable and widget.items|length > 1 %}data-sortable{% endif %}>
+<table class="controlcenter__table"{% if widget.sortable and widget.items|length > 1 %} data-sortable{% endif %}>
     {% if widget.items and widget.sortable %}
         <thead class="controlcenter__table__thead">
             <tr class="controlcenter__table__tr">
@@ -10,7 +10,7 @@
         </thead>
     {% endif %}
     <tbody class="controlcenter__table__tbody">
-        {% for key, value in ̰ widget.items %}
+        {% for key, value in widget.items %}
             <tr class="controlcenter__table__tr">
                 <th class="controlcenter__table__th controlcenter__table__th--{{ key.label|default:key|slugify }}">
                     {% include "controlcenter/snippets/generic_item.html" with item=key %}


### PR DESCRIPTION
There is an invisible 0x00a0 character after `in`

```
controlcenter/templates/controlcenter/widgets/contrib/key_value_list.html:
TemplateSyntaxError 'for' statements should use the format 'for x in y': for key, value in ̰ widget.items
```