### PR TITLE
i think that regardless sortability, the table header should be always

### DIFF
--- a/controlcenter/templates/controlcenter/widgets/itemlist.html
+++ b/controlcenter/templates/controlcenter/widgets/itemlist.html
@@ -1,6 +1,6 @@
 {% load controlcenter_tags %}
 <table class="controlcenter__table" {% if widget.sortable and widget.values|length > 1 %}data-sortable{% endif %}>
-    {% if widget.sortable and widget.list_display and widget.values %}
+    {% if widget.list_display and widget.values %}
         <thead class="controlcenter__table__thead">
             <tr class="controlcenter__table__tr">
                 {% for attr in widget.list_display %}


### PR DESCRIPTION
shown.  one can always unset list_display resulting in no header.

sorting is not on by default i imagine because of the problems with sorting arbitrary data
and that is fine.  but the table header should not be a dependency of sorting.