### PR TITLE
in-template temporary fix for chartist-plugin-pointlabels #19

### DIFF
--- a/controlcenter/templates/controlcenter/widgets/chart.html
+++ b/controlcenter/templates/controlcenter/widgets/chart.html
@@ -23,6 +23,8 @@
                   labelInterpolationFnc: function (label) {
                       return label.split(', ')[1];
                   },
+                  {% else %}
+                  labelInterpolationFnc: function (label) { return label ? label : 0 }
                   {% endif %}
                 })
             ];


### PR DESCRIPTION
`0`s show up as `undefined` in the point labels.
https://github.com/gionkunz/chartist-plugin-pointlabels/issues/19