### PR TITLE
docs: use dynamic axes to scale y-axes

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -164,6 +164,9 @@ Displaying series in legend
                 'axisY': {
                     'onlyInteger': True
                 },
+                'axisX': {
+                    'onlyInteger': True
+                },
                 # Visual tuning
                 'chartPadding': {
                     'top': 24,

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -161,7 +161,9 @@ Displaying series in legend
         class Chartist:
             options = {
                 # Displays only integer values on y-axis
-                'onlyInteger': True,
+                'axisY': {
+                    'onlyInteger': True
+                },
                 # Visual tuning
                 'chartPadding': {
                     'top': 24,


### PR DESCRIPTION
I just fixed the documentation to use only integer values on the y-axes, as the proposed solution in the documentation did not work for me.

See https://github.com/gionkunz/chartist-js/issues/423.