### PR TITLE
Fix compatibility with Python 3.10

### DIFF
--- a/controlcenter/widgets/core.py
+++ b/controlcenter/widgets/core.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Sequence
 import itertools
 import os
 from abc import ABCMeta
@@ -85,7 +85,7 @@ class BaseWidget(BaseModel, metaclass=WidgetMeta):
         return queryset
 
 
-class Group(collections.Sequence):
+class Group(Sequence):
     def __init__(self, widgets=None, attrs=None, width=None, height=None):
         self.widgets = tuple(widgets or ())
         self.attrs = (attrs or {}).copy()


### PR DESCRIPTION
Fixes deprecation message in Python 3.3+ and fixes compatibility with PYthon 3.10
Resolves issue #62

controlcenter\widgets\core.py:88: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working