### PR TITLE
Update instructions to avoid 404 error when pointing to a dashboard.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,8 +76,8 @@ Plug in urls:
     from controlcenter.views import controlcenter
 
     urlpatterns = [
-        path('admin/', admin.site.urls),
         path('admin/dashboard/', controlcenter.urls),
+        path('admin/', admin.site.urls),
         ...
     ]
 


### PR DESCRIPTION
Fix #66